### PR TITLE
Fixing issue with data loader fetching 3-samples minibatch.

### DIFF
--- a/dataloaders/subset_random_dataloader.py
+++ b/dataloaders/subset_random_dataloader.py
@@ -16,11 +16,12 @@ def null_collate(batch):
     return images, labels
 
 class SubsetRandomDataLoader(DataLoader):
-    def __init__(self, dataset, indexes, batch_size):
+    def __init__(self, dataset, indexes, batch_size, drop_last=False):
         loader_params = dict(
             batch_size=batch_size,
             num_workers=1,
             pin_memory=True,
             collate_fn=null_collate
         )
-        super(SubsetRandomDataLoader, self).__init__(dataset=dataset, sampler=SubsetRandomSampler(indexes), **loader_params)
+        sampler = SubsetRandomSampler(indexes)
+        super(SubsetRandomDataLoader, self).__init__(dataset=dataset, sampler=sampler, drop_last=drop_last, **loader_params)

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -29,7 +29,7 @@ class Trainer:
         #     stratify=self.train_dataset.labels
         # )
 
-        self.train_loader = SubsetRandomDataLoader(dataset, train_idx, batch_size)
+        self.train_loader = SubsetRandomDataLoader(dataset, train_idx, batch_size, drop_last=True)
         self.validation_loader = SubsetRandomDataLoader(dataset, validation_idx, batch_size)
         
         print('Train set: {}'.format(len(train_idx)))


### PR DESCRIPTION
This solves issue:
https://github.com/defeatcovid19/defeatcovid19-net-pytorch/issues/4
The solution simply ensures that drop_last flag (referred to minibatch) is True in training dataloader.