### PR TITLE
Add TorchXRayVisionDataset

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,3 +1,4 @@
 from .chest_xray_pneumonia_dataset import ChestXRayPneumoniaDataset
 from .covid_chestxray_dataset import COVIDChestXRayDataset
 from .nih_cx38_dataset import NIHCX38Dataset
+from .torchxrayvision_dataset import TorchXRayVisionDataset

--- a/datasets/nih_cx38_dataset.py
+++ b/datasets/nih_cx38_dataset.py
@@ -6,10 +6,35 @@ from torch.utils.data import Dataset
 
 class NIHCX38Dataset(Dataset):
     ''' Integrates the National Institutes of Health Clinical Center chest x-ray dataset.
-    
+
     Dataset description: https://www.nih.gov/news-events/news-releases/nih-clinical-center-provides-one-largest-publicly-available-chest-x-ray-datasets-scientific-community
-    Download the dataset from https://nihcc.app.box.com/v/ChestXray-NIHCC to the folder input/nih-cx38
-    Extract all image_??.tar.gz to the input/nih-cx38/images/ folder and ensure input/nih-cx38/Data_Entry_2017.csv is present.
+
+    To use this class:
+
+    - Download the dataset from https://nihcc.app.box.com/v/ChestXray-NIHCC
+      to the folder `input/nih-cx38`.
+    - Extract all `image_??.tar.gz` to the `input/nih-cx38/images/` folder and
+      ensure `input/nih-cx38/Data_Entry_2017.csv` is present.
+
+    Example usage of NIHCX38Dataset::
+
+        dataset = NIHCX38Dataset(Path('input/nih-cx38'), 224, balance=True)
+
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to the dataset artifacts
+
+    size : int
+        Resize images to this size.
+
+    augment : callable
+        If not None, will be called with the image instance.
+
+    balance : bool
+        If set to True, create a balanced dataset by undersampling the category
+        class with higher number of instances.
     '''
 
     def __init__(self, path, size=128, augment=None, balance=False):

--- a/datasets/torchxrayvision_dataset.py
+++ b/datasets/torchxrayvision_dataset.py
@@ -1,0 +1,68 @@
+import cv2
+import pandas as pd
+import numpy as np
+from PIL import Image
+from torch.utils.data import Dataset
+
+import torchxrayvision as xrv
+
+class TorchXRayVisionDataset(Dataset):
+    ''' This class is an adapter for torchxrayvision datasets.
+    
+    More info: https://github.com/mlmed/torchxrayvision
+    '''
+
+    def __init__(self, xrv_dataset, pathologies=['Pneumonia'], augment=None, balance=False):
+        super(TorchXRayVisionDataset, self).__init__()
+        print('{} initialized with xrv_dataset={}'.format(self.__class__.__name__, xrv_dataset.__class__.__name__))
+        self.xrv_dataset = xrv_dataset
+        self.augment = augment
+
+        # determinate binary labels
+        pathology_mask = np.zeros(len(xrv_dataset.pathologies))
+        for pathology in pathologies:
+            idx = xrv_dataset.pathologies.index(pathology)
+            pathology_mask[idx] = 1
+        labels_mask = np.any(np.logical_and(xrv_dataset.labels, pathology_mask), axis=1)
+
+        if balance:
+            pos_indices = np.arange(len(labels_mask))[labels_mask]
+            neg_indices = np.arange(len(labels_mask))[~labels_mask]
+            if len(pos_indices) < len(neg_indices):
+                neg_indices = np.random.choice(neg_indices, len(pos_indices))
+            else:
+                pos_indices = np.random.choice(pos_indices, len(neg_indices))
+
+            self.labels = np.concatenate((
+                np.zeros(len(neg_indices)),
+                np.ones(len(pos_indices))
+            )).reshape(-1, 1)
+            self.item_indices = np.concatenate((neg_indices, pos_indices))
+        else:
+            self.labels = labels_mask.astype(int)
+            self.item_indices = np.arange(len(self.labels))
+
+        print("Dataset size: {}".format(len(self.labels)))
+        print("  Number of positive cases: {}".format(sum(self.labels)))
+        print("  Number of negative cases: {}".format(len(self.labels) - sum(self.labels)))
+    
+    def __getitem__(self, index):
+
+        item = self.xrv_dataset[self.item_indices[index]]
+        label = self.labels[index]
+        img = item['PA']
+            
+        # xrv works with [-1024; 1024] value range. scale it to [0; 255]
+        xrv_min = -1024
+        xrv_max = 1024
+        img = ((img - xrv_min) / (xrv_max - xrv_min) * 255).astype('uint8')
+
+        if img.shape[0] == 1:
+            img = img.repeat(3, axis=0)
+        if self.augment is not None:
+            img = self.augment(img)
+
+        return img, label.item()
+
+    def __len__(self):
+        return self.item_indices.shape[0]

--- a/datasets/torchxrayvision_dataset.py
+++ b/datasets/torchxrayvision_dataset.py
@@ -1,15 +1,58 @@
-import cv2
-import pandas as pd
 import numpy as np
-from PIL import Image
 from torch.utils.data import Dataset
 
-import torchxrayvision as xrv
-
 class TorchXRayVisionDataset(Dataset):
-    ''' This class is an adapter for torchxrayvision datasets.
-    
+    '''
+    TorchXRayVision Dataset
+
+    The TorchXRayVisionDataset class in wraps a torchxrayvision.dataset
+    instance to a dataset used by this project, so all public datasets
+    supported by the `torchxrayvision`_ library can be used to train the model.
+
+    To use this dataset wrapper:
+     - install torchxrayvision with `pip install torchxrayvision`,
+     - download one of the datasets supported by torchxrayvision
+       (see `torchxrayvision.datasets`_ module)
+     - create an instance of one of the `torchxrayvision.datasets`_ classes,
+     - pass this instance to  the TorchXRayVisionDataset_ initializer.
+
     More info: https://github.com/mlmed/torchxrayvision
+
+    Example usage of TorchXRayVisionDataset::
+
+        import torchvision
+        import torchxrayvision as xrv
+
+        transform = torchvision.transforms.Compose([xrv.datasets.XRayCenterCrop(),
+                                                    xrv.datasets.XRayResizer(size)])
+
+        kaggle_dataset = xrv.datasets.Kaggle_Dataset(
+            imgpath='dataset_folder/image_folder',
+            csvpath='dataset_folder/stage_2_train_labels.csv',
+            transform=transform)
+
+        dataset = TorchXRayVisionDataset(kaggle_dataset, balance=True)
+
+    .. _torchxrayvision: https://github.com/mlmed/torchxrayvision
+    .. _torchxrayvision.datasets: https://github.com/mlmed/torchxrayvision/blob/master/torchxrayvision/datasets.py
+
+
+    Parameters
+    ----------
+    xrv_dataset : torchxrayvision.datasets.Dataset
+        The torchxrayvision dataset instance.
+
+    pathologies : list<str>
+        The list of pathology labels that should be evaluated as True label.
+        A subset of torchxrayvision.datasets.Dataset.pathologies property of 
+        your torchxrayvision dataset instance.
+
+    augment : callable
+        If not None, will be called with the image instance.
+
+    balance : bool
+        If set to True, create a balanced dataset by undersampling the category
+        class with higher number of instances.
     '''
 
     def __init__(self, xrv_dataset, pathologies=['Pneumonia'], augment=None, balance=False):

--- a/train.py
+++ b/train.py
@@ -1,7 +1,7 @@
 import copy
 import diagnostics
 from pathlib import Path
-from datasets import ChestXRayPneumoniaDataset, COVIDChestXRayDataset, NIHCX38Dataset, TorchXRayVisionDataset
+from datasets import ChestXRayPneumoniaDataset, COVIDChestXRayDataset, NIHCX38Dataset
 from models import Resnet34
 from trainer import Trainer
 from sklearn.model_selection import train_test_split, StratifiedKFold
@@ -34,6 +34,8 @@ dataset = ChestXRayPneumoniaDataset(Path('input/chest-xray-pneumonia'), size)
 # # Example usage of TorchXRayVisionDataset (see also https://github.com/mlmed/torchxrayvision)
 # import torchvision
 # import torchxrayvision as xrv
+# from datasets import TorchXRayVisionDataset
+#
 # transform = torchvision.transforms.Compose([xrv.datasets.XRayCenterCrop(),
 #                                             xrv.datasets.XRayResizer(size)])
 # kaggle_dataset = xrv.datasets.Kaggle_Dataset(

--- a/train.py
+++ b/train.py
@@ -1,7 +1,7 @@
 import copy
 import diagnostics
 from pathlib import Path
-from datasets import ChestXRayPneumoniaDataset, COVIDChestXRayDataset, NIHCX38Dataset
+from datasets import ChestXRayPneumoniaDataset, COVIDChestXRayDataset, NIHCX38Dataset, TorchXRayVisionDataset
 from models import Resnet34
 from trainer import Trainer
 from sklearn.model_selection import train_test_split, StratifiedKFold
@@ -25,13 +25,30 @@ n_splits = 5
 
 # Pretrain with Chest XRay Pneumonia dataset (>5k images)
 pneumonia_classifier = Resnet34()
+
 dataset = ChestXRayPneumoniaDataset(Path('input/chest-xray-pneumonia'), size)
+
+# # Example usage of NIHCX38Dataset:
 # dataset = NIHCX38Dataset(Path('input/nih-cx38'), size, balance=True)
+
+# # Example usage of TorchXRayVisionDataset (see also https://github.com/mlmed/torchxrayvision)
+# import torchvision
+# import torchxrayvision as xrv
+# transform = torchvision.transforms.Compose([xrv.datasets.XRayCenterCrop(),
+#                                             xrv.datasets.XRayResizer(size)])
+# kaggle_dataset = xrv.datasets.Kaggle_Dataset(
+#     imgpath='dataset_folder/image_folder',
+#     csvpath='dataset_folder/stage_2_train_labels.csv',
+#     transform=transform)
+# dataset = TorchXRayVisionDataset(kaggle_dataset, balance=True)
+
+
 train_idx, validation_idx = train_test_split(
     list(range(len(dataset))),
     test_size=0.2,
     stratify=dataset.labels
 )
+
 trainer = Trainer(pneumonia_classifier, dataset, batch_size, train_idx, validation_idx)
 trainer.run(max_epochs=2)
 

--- a/train.py
+++ b/train.py
@@ -28,23 +28,6 @@ pneumonia_classifier = Resnet34()
 
 dataset = ChestXRayPneumoniaDataset(Path('input/chest-xray-pneumonia'), size)
 
-# # Example usage of NIHCX38Dataset:
-# dataset = NIHCX38Dataset(Path('input/nih-cx38'), size, balance=True)
-
-# # Example usage of TorchXRayVisionDataset (see also https://github.com/mlmed/torchxrayvision)
-# import torchvision
-# import torchxrayvision as xrv
-# from datasets import TorchXRayVisionDataset
-#
-# transform = torchvision.transforms.Compose([xrv.datasets.XRayCenterCrop(),
-#                                             xrv.datasets.XRayResizer(size)])
-# kaggle_dataset = xrv.datasets.Kaggle_Dataset(
-#     imgpath='dataset_folder/image_folder',
-#     csvpath='dataset_folder/stage_2_train_labels.csv',
-#     transform=transform)
-# dataset = TorchXRayVisionDataset(kaggle_dataset, balance=True)
-
-
 train_idx, validation_idx = train_test_split(
     list(range(len(dataset))),
     test_size=0.2,

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -6,9 +6,15 @@ import torch.nn as nn
 from timeit import default_timer as timer
 from torch.utils.data import Dataset
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import roc_auc_score
+from sklearn.metrics import accuracy_score, roc_auc_score
 from dataloaders import SubsetRandomDataLoader
 from metrics import Accuracy
+
+def roc_auc_score_robust(y_true, y_pred):
+    if len(np.unique(y_true)) == 1:
+        return accuracy_score(y_true, np.rint(y_pred))
+    else:
+        return roc_auc_score(y_true, y_pred)
 
 class Trainer:
     def __init__(self, classifier, dataset, batch_size, train_idx, validation_idx):
@@ -55,7 +61,7 @@ class Trainer:
 
         criterion = nn.BCELoss()
         criterion = criterion.cuda()
-        metrics = [Accuracy(), roc_auc_score]
+        metrics = [Accuracy(), roc_auc_score_robust]
 
         print("{}'".format(self.optimizer))
         print("{}'".format(self.scheduler))

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -6,15 +6,9 @@ import torch.nn as nn
 from timeit import default_timer as timer
 from torch.utils.data import Dataset
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, roc_auc_score
+from sklearn.metrics import roc_auc_score
 from dataloaders import SubsetRandomDataLoader
 from metrics import Accuracy
-
-def roc_auc_score_robust(y_true, y_pred):
-    if len(np.unique(y_true)) == 1:
-        return accuracy_score(y_true, np.rint(y_pred))
-    else:
-        return roc_auc_score(y_true, y_pred)
 
 class Trainer:
     def __init__(self, classifier, dataset, batch_size, train_idx, validation_idx):
@@ -61,7 +55,7 @@ class Trainer:
 
         criterion = nn.BCELoss()
         criterion = criterion.cuda()
-        metrics = [Accuracy(), roc_auc_score_robust]
+        metrics = [Accuracy(), roc_auc_score]
 
         print("{}'".format(self.optimizer))
         print("{}'".format(self.scheduler))


### PR DESCRIPTION
This dataset wraps a torchxrayvision.dataset instance to a dataset used by this project, so all public datasets supported by the [torchxrayvision](https://github.com/mlmed/torchxrayvision) library can be used to train this model.

To use this dataset wrapper:
 - install torchxrayvision with `pip install torchxrayvision`,
 - download one of the datasets [supported by torchxrayvision](https://github.com/mlmed/torchxrayvision/blob/master/torchxrayvision/datasets.py)
 - create an instance of one of the [torchxrayvision.datasets],(https://github.com/mlmed/torchxrayvision/blob/master/torchxrayvision/datasets.py) classes,
 - pass this instance to  the `TorchXRayVisionDataset` initializer.